### PR TITLE
Modifications to convenience functions

### DIFF
--- a/factom/client.py
+++ b/factom/client.py
@@ -301,7 +301,9 @@ class Factomd(BaseAPI):
 
     # Convenience methods
 
-    def read_chain(self, chain_id: str, from_height: int = 0, include_entry_context: bool = False, encode_as_hex: bool = False) -> list:
+    def read_chain(
+        self, chain_id: str, from_height: int = 0, include_entry_context: bool = False, encode_as_hex: bool = False
+    ):
         """A generator that yields all entries of a chain in order, optionally starting from a given block height."""
         # Walk the entry block chain backwards to build up a stack of entry blocks to fetch
         entry_blocks = []
@@ -316,7 +318,7 @@ class Factomd(BaseAPI):
         # Continuously pop off the stack and yield each entry one by one (in the order that they appear in the block)
         while len(entry_blocks) > 0:
             entry_block = entry_blocks.pop()
-            for entry_pointer in reversed(entry_block["entrylist"]):
+            for entry_pointer in entry_block["entrylist"]:
                 entry = self.entry(entry_pointer["entryhash"], encode_as_hex=encode_as_hex)
                 if include_entry_context:
                     entry["entryhash"] = entry_pointer["entryhash"]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author="Ben Homnick",
     author_email="bhomnick@gmail.com",
     name="factom-api",
-    version='1.0.1',
+    version='1.0.2',
     description="Python client library for the Factom API",
     long_description=long_description,
     license='MIT License',


### PR DESCRIPTION
- Convert `read_chain()` into a generator with optional start height
- Added a `entries_at_height()` function for quickly getting the entries of a chain from an arbitrary height, without needing to walk the entry blocks backwards